### PR TITLE
Add libbsd to makefile for compilation on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,14 @@ INSTALL_DATA ?= install
 X11BASE	?= /usr/X11R6
 INCLUDES?= -I$(X11BASE)/include
 LDPATH	?= -L$(X11BASE)/lib
-LIBS	+= -lX11 -lXrandr -lXext -lm -lbsd
+LIBS	+= -lX11 -lXrandr -lXext -lm
 
 PROG	= xdimmer
 OBJS	= xdimmer.o
+
+ifeq ($(shell uname), Linux)
+	LIBS += -lbsd
+endif
 
 all: $(PROG)
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ INSTALL_DATA ?= install
 X11BASE	?= /usr/X11R6
 INCLUDES?= -I$(X11BASE)/include
 LDPATH	?= -L$(X11BASE)/lib
-LIBS	+= -lX11 -lXrandr -lXext -lm
+LIBS	+= -lX11 -lXrandr -lXext -lm -lbsd
 
 PROG	= xdimmer
 OBJS	= xdimmer.o


### PR DESCRIPTION
This adds `-lbsd` to `LIBS` in the makefile so xdimmer compiles on Linux without errors. I'm not sure if this will break BSD compatibility.